### PR TITLE
Fix instructions to not assume that PYTHONPATH contains the cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ pip install -r requirements.txt
 # Usage
 
 ```bash
-$ python pageomat/main.py -h
+$ python -m pageomat.main -h
 usage: main.py [-h] --config CONFIG --output OUTPUT
 
 Runs Page-o-Mat
@@ -53,7 +53,7 @@ options:
   --config CONFIG  name of the journal YAML config file
   --output OUTPUT  name of the pdf file
 
-$ python pageomat/main.py --config config/2024-recurring-journal.yaml --output 2024.pdf
+$ python -m pageomat.main --config config/2025-journal.yaml --output 2025.pdf
 ```
 
 Sample configuration files can be found in the `config` folder.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ date format you wish.
    `pip install -r requirements.txt`
 1. Run Page-o-Mat with a config
 
-   `python pageomat/main.py --config config/daily.yaml --output daily.pdf`
+   `python -m pageomat.main --config config/daily.yaml --output daily.pdf`
 
 1. daily.pdf is a sample 2023 Daily Journal PDF. It has 365 pages, each with the date on top.
 
@@ -67,3 +67,13 @@ pages:
 ```
 
 There are more sample configurations in the config folder.
+
+## Running Tests
+
+If you make local changes and want to ensure that they do not break existing
+behavior, you can run the Page-o-mat tests by running the following:
+
+   `python -m unittest discover -s tests -p 'test_*.py'`
+
+Alternatively, if you have `pytest` installed, you can run the tests by simply
+running `pytest`.

--- a/pageomat/main.py
+++ b/pageomat/main.py
@@ -2,7 +2,7 @@
 """
 import sys
 import yaml
-from cli_arg_parser import CliArgParser
+from pageomat.cli_arg_parser import CliArgParser
 from pageomat.pdf_generator import PdfGenerator
 
 


### PR DESCRIPTION
- Specify the main entry point via "-m pageomat.main"
- Fix import of CliArgParser
- Update example command line to create 2025 planner
- Add instructions for running the tests